### PR TITLE
Add method to get all class names

### DIFF
--- a/include/XTypeRegistry.hpp
+++ b/include/XTypeRegistry.hpp
@@ -16,6 +16,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <set>
 
 /**
  * XType v3
@@ -53,6 +54,9 @@ namespace xtypes
 
         /// Function to register an alias to an existing class (useful for conversions)
         bool register_alias(const std::string& original, const std::string& alias);
+
+        /// Get all registered classnames
+        std::set<std::string> get_classnames() const;
 
         /// Check if a classname is known to the registry
         bool knows_class(const std::string& with_name) const;

--- a/pybind/pyXTypeRegistry.cpp
+++ b/pybind/pyXTypeRegistry.cpp
@@ -17,6 +17,7 @@ void PYBIND11_INIT_REGISTRY(py::module_& m) {
     py::class_<XTypeRegistry, std::shared_ptr<XTypeRegistry> >(m, "XTypeRegistry")
         .def(py::init())
         .def("register_alias", &XTypeRegistry::register_alias)
+        .def("get_classnames", &XTypeRegistry::get_classnames)
         .def("knows_class", &XTypeRegistry::knows_class)
         .def("instantiate_from", &XTypeRegistry::instantiate_from)
         .def("import_from", &XTypeRegistry::import_from)

--- a/src/XTypeRegistry.cpp
+++ b/src/XTypeRegistry.cpp
@@ -18,6 +18,16 @@ bool XTypeRegistry::register_alias(const std::string& original, const std::strin
     return true;
 }
 
+std::set<std::string> XTypeRegistry::get_classnames() const
+{
+    std::set<std::string> classes;
+    for (const auto &[classname, func] : _factories)
+    {
+        classes.insert(classname);
+    }
+    return classes;
+}
+
 bool XTypeRegistry::knows_class(const std::string& with_name) const
 {
     if (_factories.find(with_name) != _factories.end())


### PR DESCRIPTION
This PR adds the `get_classnames` method to retrieve the registered class names for enumeration in other tools.